### PR TITLE
Allow skipping stacks on traceable errors

### DIFF
--- a/meep.go
+++ b/meep.go
@@ -5,6 +5,8 @@ func Meep(err error, opts ...Opts) error {
 }
 
 func New(err error, opts ...Opts) error {
+	opt := flattenOpts(opts)
+
 	// for `TraitAutodescribing`:
 	if m, ok := err.(meepAutodescriber); ok {
 		m.isMeepAutodescriber().self = err
@@ -12,16 +14,15 @@ func New(err error, opts ...Opts) error {
 
 	// for `TraitTraceable`:
 	if m, ok := err.(meepTraceable); ok {
-		m.isMeepTraceable().Stack = *captureStack()
+		if !opt.nostack {
+			m.isMeepTraceable().Stack = *captureStack()
+		}
 	}
 
 	// for `TraitCausable`:
 	if m, ok := err.(meepCausable); ok {
-		for _, o := range opts {
-			if o.cause != nil {
-				m.isMeepCausable().Cause = o.cause
-				break
-			}
+		if opt.cause != nil {
+			m.isMeepCausable().Cause = opt.cause
 		}
 	}
 
@@ -29,9 +30,29 @@ func New(err error, opts ...Opts) error {
 }
 
 type Opts struct {
-	cause error
+	cause   error
+	nostack bool
+}
+
+func flattenOpts(opts []Opts) Opts {
+	v := Opts{}
+	for _, o := range opts {
+		if o.cause != nil {
+			v.cause = o.cause
+		}
+		if o.nostack == true {
+			v.nostack = true
+		}
+
+	}
+	return v
+
 }
 
 func Cause(x error) Opts {
 	return Opts{cause: New(x)}
+}
+
+func NoStack() Opts {
+	return Opts{nostack: true}
 }

--- a/meep.go
+++ b/meep.go
@@ -49,10 +49,32 @@ func flattenOpts(opts []Opts) Opts {
 
 }
 
+/*
+	Use `Cause` to tell `Meep()` that it should attach another error as a
+	cause to the error it's initializating.
+
+	Usage:
+
+		meep.Meep(
+			&ErrSomethingCausable{},
+			meep.Cause(fmt.Errorf("the root cause")),
+		)
+*/
 func Cause(x error) Opts {
 	return Opts{cause: New(x)}
 }
 
+/*
+	Use `NoStack` to tell `Meep()` that it should skip gathering a stack trace
+	for this error, even if it has `TraitTraceable`.
+
+	Usage:
+
+		meep.Meep(
+			&ErrUsuallyHasAStacktrace{},
+			meep.NoStack(), // skip stacks this time.
+		)
+*/
 func NoStack() Opts {
 	return Opts{nostack: true}
 }

--- a/trait_autodescriber.go
+++ b/trait_autodescriber.go
@@ -90,11 +90,13 @@ func customDescribe(typ reflect.Type) (consumed bool, desc func(reflect.Value, i
 		}
 	case reflect.TypeOf(TraitTraceable{}):
 		return true, func(f reflect.Value, buf io.Writer) {
+			m := reflect.Indirect(f).Interface().(TraitTraceable)
+			if !m.IsStackSet() {
+				return
+			}
 			buf = indenter(buf)
 			buf.Write([]byte("Stack trace:\n"))
 			buf = indenter(buf)
-			//buf.(*rediscipliner).prefix = []byte{} // stacks already tab themselves in once
-			m := reflect.Indirect(f).Interface().(TraitTraceable)
 			m.WriteStack(buf)
 		}
 	case reflect.TypeOf(TraitCausable{}):

--- a/trait_traceable.go
+++ b/trait_traceable.go
@@ -16,6 +16,10 @@ type meepTraceable interface {
 
 func (m *TraitTraceable) isMeepTraceable() *TraitTraceable { return m }
 
+func (m TraitTraceable) IsStackSet() bool {
+	return len(m.Stack.Frames) > 0
+}
+
 /*
 	Return the stack of the error formatted as a human readable string:
 	one frame per line.  Each line lists the source file, line number, and
@@ -30,7 +34,8 @@ func (m TraitTraceable) StackString() string {
 // Same job as StackString; use StackString for convenience, use this for performance.
 func (m TraitTraceable) WriteStack(w io.Writer) {
 	if len(m.Stack.Frames) == 0 {
-		panic("meep:uninitialized")
+		w.Write([]byte("meep:uninitialized"))
+		return
 	}
 	for _, fr := range m.Stack.Frames {
 		//w.Write(tab)

--- a/trait_traceable.go
+++ b/trait_traceable.go
@@ -34,7 +34,7 @@ func (m TraitTraceable) StackString() string {
 // Same job as StackString; use StackString for convenience, use this for performance.
 func (m TraitTraceable) WriteStack(w io.Writer) {
 	if len(m.Stack.Frames) == 0 {
-		w.Write([]byte("meep:uninitialized"))
+		w.Write([]byte("stack info not tracked"))
 		return
 	}
 	for _, fr := range m.Stack.Frames {


### PR DESCRIPTION
Add the option to let callers skip capturing stacks -- even if the error type usually gets them because it has `TraitTraceable` -- when calling `Meep`.

The default is by far to always capture stacks for an error with the Traceable trait.  But exceptions exist (so far, the only defensible ones are where an error type is sometimes recursive in its own cause, and only the first stack matters), so, here's support.
